### PR TITLE
Update Utilties.CloneObject and normalise line endings.

### DIFF
--- a/CathodeLib/Scripts/Utilities.cs
+++ b/CathodeLib/Scripts/Utilities.cs
@@ -187,14 +187,7 @@ namespace CathodeLib
         //Clones an object (slow!)
         public static T CloneObject<T>(T obj)
         {
-            //A somewhat hacky an inefficient way of deep cloning an object (TODO: optimise this as we use it a lot!)
-            MemoryStream ms = new MemoryStream();
-            new BinaryFormatter().Serialize(ms, obj);
-            ms.Position = 0;
-            T obj2 = (T)new BinaryFormatter().Deserialize(ms);
-            ms.Close();
-            return obj2;
-            //obj.MemberwiseClone();
+            return ( T ) obj.GetType().GetMethod("MemberwiseClone", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic).Invoke(obj, Array.Empty<object>());
         }
 
         //Generate a hashed string for use in the animation system (FNV hash)


### PR DESCRIPTION
The 2nd change wasn't really intentional, but from the web editor of GitHub.